### PR TITLE
Add "request audio transcode format"

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
@@ -75,6 +75,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 	private ListPreference maxBitrateMobile;
 	private ListPreference maxVideoBitrateWifi;
 	private ListPreference maxVideoBitrateMobile;
+	private ListPreference audioTranscodeFormat;
 	private ListPreference networkTimeout;
 	private CacheLocationPreference cacheLocation;
 	private ListPreference preloadCountWifi;
@@ -241,6 +242,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		maxBitrateMobile = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_MAX_BITRATE_MOBILE);
 		maxVideoBitrateWifi = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_MAX_VIDEO_BITRATE_WIFI);
 		maxVideoBitrateMobile = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_MAX_VIDEO_BITRATE_MOBILE);
+		audioTranscodeFormat = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_AUDIO_TRANSCODE_FORMAT);
 		networkTimeout = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_NETWORK_TIMEOUT);
 		cacheLocation = (CacheLocationPreference) this.findPreference(Constants.PREFERENCES_KEY_CACHE_LOCATION);
 		preloadCountWifi = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_PRELOAD_COUNT_WIFI);
@@ -398,6 +400,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 			maxBitrateMobile.setSummary(maxBitrateMobile.getEntry());
 			maxVideoBitrateWifi.setSummary(maxVideoBitrateWifi.getEntry());
 			maxVideoBitrateMobile.setSummary(maxVideoBitrateMobile.getEntry());
+			audioTranscodeFormat.setSummary(audioTranscodeFormat.getEntry());
 			networkTimeout.setSummary(networkTimeout.getEntry());
 			cacheLocation.setSummary(cacheLocation.getText());
 			preloadCountWifi.setSummary(preloadCountWifi.getEntry());

--- a/app/src/main/java/github/daneren2005/dsub/service/CachedMusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/CachedMusicService.java
@@ -748,13 +748,13 @@ public class CachedMusicService implements MusicService {
     }
 
     @Override
-    public HttpURLConnection getDownloadInputStream(Context context, Entry song, long offset, int maxBitrate, SilentBackgroundTask task) throws Exception {
-        return musicService.getDownloadInputStream(context, song, offset, maxBitrate, task);
+    public HttpURLConnection getDownloadInputStream(Context context, Entry song, long offset, int maxBitrate, String format, SilentBackgroundTask task) throws Exception {
+        return musicService.getDownloadInputStream(context, song, offset, maxBitrate, format, task);
     }
 
 	@Override
-	public String getMusicUrl(Context context, Entry song, int maxBitrate) throws Exception {
-		return musicService.getMusicUrl(context, song, maxBitrate);
+	public String getMusicUrl(Context context, Entry song, int maxBitrate, String format) throws Exception {
+		return musicService.getMusicUrl(context, song, maxBitrate, format);
 	}
 
 	@Override

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
@@ -120,7 +120,7 @@ public class DownloadFile implements BufferFile {
 
 	public String getTranscodeFormat() {
 		String TranscodeFormat = Util.getTranscodeFormat(context);
-		if (TranscodeFormat != null || !(TranscodeFormat.equals("raw"))) {
+		if (TranscodeFormat != null || !("raw".equals(TranscodeFormat))) {
 				song.setTranscodedSuffix(TranscodeFormat);
 			}
 		return TranscodeFormat;

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
@@ -55,6 +55,7 @@ public class DownloadFile implements BufferFile {
 	private boolean failedDownload = false;
     private int failed = 0;
     private int bitRate;
+	private String format;
 	private boolean isPlaying = false;
 	private boolean saveWhenDone = false;
 	private boolean completeWhenDone = false;
@@ -66,6 +67,7 @@ public class DownloadFile implements BufferFile {
         this.context = context;
         this.song = song;
         this.save = save;
+		format = getTranscodeFormat();	//must come before saveFile gets created
         saveFile = FileUtil.getSongFile(context, song);
         bitRate = getActualBitrate();
         partialFile = new File(saveFile.getParent(), FileUtil.getBaseName(saveFile.getName()) +
@@ -114,6 +116,14 @@ public class DownloadFile implements BufferFile {
 		}
 
 		return br;
+	}
+
+	public String getTranscodeFormat() {
+		String TranscodeFormat = Util.getTranscodeFormat(context);
+		if (TranscodeFormat != null || !(TranscodeFormat.equals("raw"))) {
+				song.setTranscodedSuffix(TranscodeFormat);
+			}
+		return TranscodeFormat;
 	}
 	
 	public Long getContentLength() {
@@ -459,7 +469,7 @@ public class DownloadFile implements BufferFile {
 				}
 				if(compare) {
 					// Attempt partial HTTP GET, appending to the file if it exists.
-					HttpURLConnection connection = musicService.getDownloadInputStream(context, song, partialFile.length(), bitRate, DownloadTask.this);
+					HttpURLConnection connection = musicService.getDownloadInputStream(context, song, partialFile.length(), bitRate, format, DownloadTask.this);
 					long contentLength = connection.getContentLength();
 					if(contentLength > 0) {
 						Log.i(TAG, "Content Length: " + contentLength);

--- a/app/src/main/java/github/daneren2005/dsub/service/MusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/MusicService.java
@@ -103,9 +103,9 @@ public interface MusicService {
 
     Bitmap getCoverArt(Context context, MusicDirectory.Entry entry, int size, ProgressListener progressListener, SilentBackgroundTask task) throws Exception;
 
-    HttpURLConnection getDownloadInputStream(Context context, MusicDirectory.Entry song, long offset, int maxBitrate, SilentBackgroundTask task) throws Exception;
+    HttpURLConnection getDownloadInputStream(Context context, MusicDirectory.Entry song, long offset, int maxBitrate, String format, SilentBackgroundTask task) throws Exception;
 
-	String getMusicUrl(Context context, MusicDirectory.Entry song, int maxBitrate) throws Exception;
+	String getMusicUrl(Context context, MusicDirectory.Entry song, int maxBitrate, String format) throws Exception;
 
 	String getVideoUrl(int maxBitrate, Context context, String id);
 	

--- a/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
@@ -226,12 +226,12 @@ public class OfflineMusicService implements MusicService {
     }
 
 	@Override
-	public HttpURLConnection getDownloadInputStream(Context context, Entry song, long offset, int maxBitrate, SilentBackgroundTask task) throws Exception {
+	public HttpURLConnection getDownloadInputStream(Context context, Entry song, long offset, int maxBitrate, String format, SilentBackgroundTask task) throws Exception {
 		throw new OfflineException(ERRORMSG);
 	}
 
 	@Override
-	public String getMusicUrl(Context context, Entry song, int maxBitrate) throws Exception {
+	public String getMusicUrl(Context context, Entry song, int maxBitrate, String format) throws Exception {
 		throw new OfflineException(ERRORMSG);
 	}
 

--- a/app/src/main/java/github/daneren2005/dsub/service/RESTMusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/RESTMusicService.java
@@ -815,7 +815,7 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public HttpURLConnection getDownloadInputStream(Context context, MusicDirectory.Entry song, long offset, int maxBitrate, SilentBackgroundTask task) throws Exception {
+    public HttpURLConnection getDownloadInputStream(Context context, MusicDirectory.Entry song, long offset, int maxBitrate, String format, SilentBackgroundTask task) throws Exception {
         String url = getRestUrl(context, "stream");
 		List<String> parameterNames = new ArrayList<String>();
 		parameterNames.add("id");
@@ -824,6 +824,11 @@ public class RESTMusicService implements MusicService {
 		List<Object> parameterValues = new ArrayList<>();
 		parameterValues.add(song.getId());
 		parameterValues.add(maxBitrate);
+
+		if(Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_TRANSCODE_AUDIO, true) && ServerInfo.checkServerVersion(context, "1.9", getInstance(context))) {
+			parameterNames.add("format");
+			parameterValues.add(format);
+		}
 
 		// If video specify what format to download
 		if(song.isVideo()) {
@@ -870,7 +875,7 @@ public class RESTMusicService implements MusicService {
     }
 
 	@Override
-	public String getMusicUrl(Context context, MusicDirectory.Entry song, int maxBitrate) throws Exception {
+	public String getMusicUrl(Context context, MusicDirectory.Entry song, int maxBitrate, String format) throws Exception {
 		StringBuilder builder = new StringBuilder(getRestUrl(context, "stream"));
 		builder.append("&id=").append(song.getId());
 
@@ -879,6 +884,9 @@ public class RESTMusicService implements MusicService {
 			builder.append("&format=raw");
 		} else {
 			builder.append("&maxBitRate=").append(maxBitrate);
+			if(Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_TRANSCODE_AUDIO, true) && ServerInfo.checkServerVersion(context, "1.9", getInstance(context))) {
+				builder.append("&format=").append(format);
+			}
 		}
 
 		String url = builder.toString();

--- a/app/src/main/java/github/daneren2005/dsub/service/RemoteController.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/RemoteController.java
@@ -164,7 +164,7 @@ public abstract class RemoteController {
 			if(song.isVideo()) {
 				url = musicService.getHlsUrl(song.getId(), downloadFile.getBitRate(), downloadService);
 			} else {
-				url = musicService.getMusicUrl(downloadService, song, downloadFile.getBitRate());
+				url = musicService.getMusicUrl(downloadService, song, downloadFile.getBitRate(), downloadFile.getTranscodeFormat());
 			}
 
 			// If proxy is going, it is a WebProxy

--- a/app/src/main/java/github/daneren2005/dsub/util/Constants.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Constants.java
@@ -94,6 +94,8 @@ public final class Constants {
     public static final String PREFERENCES_KEY_MAX_BITRATE_MOBILE = "maxBitrateMobile";
 	public static final String PREFERENCES_KEY_MAX_VIDEO_BITRATE_WIFI = "maxVideoBitrateWifi";
     public static final String PREFERENCES_KEY_MAX_VIDEO_BITRATE_MOBILE = "maxVideoBitrateMobile";
+	public static final String PREFERENCES_KEY_TRANSCODE_AUDIO = "transcodeAudio";
+	public static final String PREFERENCES_KEY_AUDIO_TRANSCODE_FORMAT = "audioTranscodeFormat";
 	public static final String PREFERENCES_KEY_NETWORK_TIMEOUT = "networkTimeout";
     public static final String PREFERENCES_KEY_CACHE_SIZE = "cacheSize";
     public static final String PREFERENCES_KEY_CACHE_LOCATION = "cacheLocation";

--- a/app/src/main/java/github/daneren2005/dsub/util/Util.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Util.java
@@ -288,6 +288,11 @@ public final class Util {
         SharedPreferences prefs = getPreferences(context);
         return Integer.parseInt(prefs.getString(wifi ? Constants.PREFERENCES_KEY_MAX_BITRATE_WIFI : Constants.PREFERENCES_KEY_MAX_BITRATE_MOBILE, "0"));
     }
+
+    public static String getTranscodeFormat(Context context) {
+		SharedPreferences prefs = getPreferences(context);
+		return prefs.getString(Constants.PREFERENCES_KEY_AUDIO_TRANSCODE_FORMAT, null);
+	}
 	
 	public static int getMaxVideoBitrate(Context context) {
         ConnectivityManager manager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -129,6 +129,26 @@
 		<item>@string/settings.max_video_bitrate_5000</item>
 		<item>@string/settings.max_bitrate_unlimited</item>
 	</string-array>
+
+	<string-array name="audioTranscodeFormatValues">
+		<item>raw</item>
+		<item>opus</item>
+		<item>ogg</item>
+		<item>aac</item>
+		<item>mp3</item>
+		<item>m4a</item>
+		<item>flac</item>
+	</string-array>
+
+	<string-array name="audioTranscodeFormatNames">
+		<item>@string/settings.audio_transcode_format_raw</item>
+		<item>@string/settings.audio_transcode_format_opus</item>
+		<item>@string/settings.audio_transcode_format_ogg</item>
+		<item>@string/settings.audio_transcode_format_aac</item>
+		<item>@string/settings.audio_transcode_format_mp3</item>
+		<item>@string/settings.audio_transcode_format_m4a</item>
+		<item>@string/settings.audio_transcode_format_flac</item>
+	</string-array>
 	
 	<string-array name="networkTimeoutValues">
 		<item>10000</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,16 @@
     <string name="settings.wifi_required_summary">Only stream media if connected to Wi-Fi</string>
     <string name="settings.local_network_required_title">Don\'t stream when roaming</string>
     <string name="settings.local_network_required_summary">Don\'t stream media while roaming</string>
+	<string name="settings.transcode_audio_title">Transcode Audio</string>
+    <string name="settings.transcode_audio_summary">Request server to transcode audio into different format</string>
+	<string name="settings.audio_transcode_format">Transcode Audio Format</string>
+	<string name="settings.audio_transcode_format_raw">raw</string>
+	<string name="settings.audio_transcode_format_opus">opus</string>
+	<string name="settings.audio_transcode_format_ogg">ogg</string>
+	<string name="settings.audio_transcode_format_aac">aac</string>
+	<string name="settings.audio_transcode_format_mp3">mp3</string>
+	<string name="settings.audio_transcode_format_m4a">m4a</string>
+	<string name="settings.audio_transcode_format_flac">flac</string>
 	<string name="settings.network_timeout_title">Network Timeout</string>
 	<string name="settings.network_timeout_10000">10 seconds</string>
 	<string name="settings.network_timeout_15000">15 seconds</string>

--- a/app/src/main/res/xml/settings_cache.xml
+++ b/app/src/main/res/xml/settings_cache.xml
@@ -35,6 +35,19 @@
 			android:entries="@array/maxVideoBitrateNames"/>
 
 		<CheckBoxPreference
+			android:title="@string/settings.transcode_audio_title"
+			android:summary="@string/settings.transcode_audio_summary"
+			android:key="transcodeAudio"
+			android:defaultValue="false"/>
+
+		<ListPreference
+			android:title="@string/settings.audio_transcode_format"
+			android:key="audioTranscodeFormat"
+			android:defaultValue="raw"
+			android:entryValues="@array/audioTranscodeFormatValues"
+			android:entries="@array/audioTranscodeFormatNames"/>
+
+		<CheckBoxPreference
 			android:title="@string/settings.wifi_required_title"
 			android:summary="@string/settings.wifi_required_summary"
 			android:key="wifiRequiredForDownload"


### PR DESCRIPTION
https://github.com/daneren2005/Subsonic/pull/987#issue-395172592

> Adds menu items in Cache/Network to optionally enable DSub to specify audio transcode format alongside subsonic musicStream requests.
> 
> Included options are:
> 
>     * raw
> 
>     * opus
> 
>     * ogg
> 
>     * aac
> 
>     * mp3
> 
>     * m4a
> 
>     * flac
> 
> 
> This subsonic feature is documented [here](http://www.subsonic.org/pages/api.jsp#stream):
> Parameter 	Required 	Default 	Comment
> format 	No 	  	(Since 1.6.0) Specifies the preferred target format (e.g., "mp3" or "flv") in case there are multiple applicable transcodings. Starting with 1.9.0 you can use the special value "raw" to disable transcoding.
> 
> Since including format is a part of the 1.6.0 (1.9.0 for raw) subsonic API spec, it is up to subsonic compatible servers that advertise 1.6.0 compliance to correctly handle this.
> I have tested this feature with **Funkwhale** and **Airsonic**:
> 
>     * **Funkwhale** handles all requested formats apart from aac and m4a correctly (will be opening a seperate issue on their gitlab for this)
> 
>     * **Airsonic** only handles the raw format request correctly but does not break on the other formats (also a separate Airsonic issue)
> 
> 
> This pull request should enable **Funkwhale** as a viable music backend for DSub, and should close:
> 
>     * [issue 958](https://github.com/daneren2005/Subsonic/issues/958)
> 
>     * [related issue on Funkwhale project](https://dev.funkwhale.audio/funkwhale/funkwhale/-/issues/989)

