### PR TITLE
Fix rendering after deleting playlist items

### DIFF
--- a/app/src/androidTest/java/github/daneren2005/dsub/adapter/EntryGridAdapterTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/adapter/EntryGridAdapterTest.java
@@ -1,0 +1,44 @@
+package github.daneren2005.dsub.adapter;
+
+
+import android.content.Context;
+import android.test.AndroidTestCase;
+import android.test.mock.MockContext;
+import android.util.Log;
+import android.view.View;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import github.daneren2005.dsub.domain.MusicDirectory.Entry;
+
+
+public class EntryGridAdapterTest extends AndroidTestCase {
+	private EntryGridAdapter mAdapter;
+
+
+	public EntryGridAdapterTest() {
+		super();
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
+
+	public void testRemoveAt() {
+		Entry a = new Entry("a");
+		Entry c = new Entry("c");
+
+		List<Entry> section = new ArrayList<>(Arrays.asList(
+				a,
+				new Entry("b"),
+				c,
+				new Entry("d"),
+				new Entry("e")));
+		mAdapter = new EntryGridAdapter(null, section, null, false);
+
+		mAdapter.removeAt(Arrays.asList(1, 3, 4));
+		assertEquals(new ArrayList<>(Arrays.asList(a, c)), section);
+	}
+}

--- a/app/src/main/java/github/daneren2005/dsub/adapter/EntryGridAdapter.java
+++ b/app/src/main/java/github/daneren2005/dsub/adapter/EntryGridAdapter.java
@@ -22,6 +22,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Iterator;
 import java.util.List;
 
 import github.daneren2005.dsub.R;
@@ -129,12 +130,20 @@ public class EntryGridAdapter extends SectionAdapter<Entry> {
 		this.showAlbum = showAlbum;
 	}
 
-	public void removeAt(int index) {
-		sections.get(0).remove(index);
-		if(header != null) {
+	public void removeAt(List<Integer> indices) {
+		List<Entry> section = sections.get(0);
+
+		Iterator iter = section.iterator();
+		int index = 0;
+
+		while (iter.hasNext()) {
+			iter.next();
+			if (indices.contains(index)){
+				iter.remove();
+			}
 			index++;
 		}
-		notifyItemRemoved(index);
+		notifyDataSetChanged();
 	}
 
 	public void setRemoveFromPlaylist(boolean removeFromPlaylist) {

--- a/app/src/main/java/github/daneren2005/dsub/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/SelectDirectoryFragment.java
@@ -917,9 +917,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 
 			@Override
 			protected void done(Void result) {
-				for(Integer index: indexes) {
-					entryGridAdapter.removeAt(index);
-				}
+				entryGridAdapter.removeAt(indexes);
 				Util.toast(context, context.getResources().getString(R.string.removed_playlist, String.valueOf(indexes.size()), name));
 			}
 


### PR DESCRIPTION
https://github.com/daneren2005/Subsonic/pull/912#issue-231802308

> Fixes #910
> 
> The existing method of removing elements from playlist has 2 issues:
> 
>     1. The removal by index ID from the storage list creates index mismatches.
> 
>     2. The UI is not updated correctly and mismatches even further.
> 
> 
> This patch users an iterator to correctly keep the data storage state correct and takes advantage of the data binding to the RecyclerView to only update the UI once and directly from the data, instead of pushing remove by index.

